### PR TITLE
math: refactored blocks to get implementation functions via getter functions

### DIFF
--- a/math/ConstArithmetic.cpp
+++ b/math/ConstArithmetic.cpp
@@ -10,6 +10,67 @@
 #include <cstdint>
 #include <string>
 
+//
+// Implementation getters, called on class construction
+//
+
+template <typename T>
+using ConstArithmeticFcn = void(*)(const T*, const T&, T*, size_t);
+
+template <typename T>
+static inline ConstArithmeticFcn<T> getXPlusKFcn()
+{
+    return [](const T* in, const T& k, T* out, const size_t num)
+    {
+        for (size_t i = 0; i < num; i++) out[i] = in[i] + k;
+    };
+}
+
+template <typename T>
+static inline ConstArithmeticFcn<T> getXSubKFcn()
+{
+    return [](const T* in, const T& k, T* out, const size_t num)
+    {
+        for (size_t i = 0; i < num; i++) out[i] = in[i] - k;
+    };
+}
+
+template <typename T>
+static inline ConstArithmeticFcn<T> getKSubXFcn()
+{
+    return [](const T* in, const T& k, T* out, const size_t num)
+    {
+        for (size_t i = 0; i < num; i++) out[i] = k - in[i];
+    };
+}
+
+template <typename T>
+static inline ConstArithmeticFcn<T> getXMultKFcn()
+{
+    return [](const T* in, const T& k, T* out, const size_t num)
+    {
+        for (size_t i = 0; i < num; i++) out[i] = in[i] * k;
+    };
+}
+
+template <typename T>
+static inline ConstArithmeticFcn<T> getXDivKFcn()
+{
+    return [](const T* in, const T& k, T* out, const size_t num)
+    {
+        for (size_t i = 0; i < num; i++) out[i] = in[i] / k;
+    };
+}
+
+template <typename T>
+static inline ConstArithmeticFcn<T> getKDivXFcn()
+{
+    return [](const T* in, const T& k, T* out, const size_t num)
+    {
+        for (size_t i = 0; i < num; i++) out[i] = k / in[i];
+    };
+}
+
 /***********************************************************************
  * |PothosDoc Const Arithmetic
  *
@@ -47,7 +108,7 @@ template <typename T>
 class ConstArithmetic: public Pothos::Block
 {
 public:
-    using ArithFcn = void(*)(const T*, const T&, T*, size_t);
+    using ArithFcn = ConstArithmeticFcn<T>;
     using Class = ConstArithmetic<T>;
 
     ConstArithmetic(
@@ -110,64 +171,6 @@ private:
 };
 
 //
-// Arithmetic functions
-//
-
-template <typename T>
-void XPlusK(const T* in, const T& k, T* out, size_t len)
-{
-    for(size_t i = 0; i < len; ++i)
-    {
-        out[i] = in[i] + k;
-    }
-}
-
-template <typename T>
-void XSubK(const T* in, const T& k, T* out, size_t len)
-{
-    for(size_t i = 0; i < len; ++i)
-    {
-        out[i] = in[i] - k;
-    }
-}
-
-template <typename T>
-void KSubX(const T* in, const T& k, T* out, size_t len)
-{
-    for(size_t i = 0; i < len; ++i)
-    {
-        out[i] = k - in[i];
-    }
-}
-
-template <typename T>
-void XMultK(const T* in, const T& k, T* out, size_t len)
-{
-    for(size_t i = 0; i < len; ++i)
-    {
-        out[i] = in[i] * k;
-    }
-}
-
-template <typename T>
-void XDivK(const T* in, const T& k, T* out, size_t len)
-{
-    for(size_t i = 0; i < len; ++i)
-    {
-        out[i] = in[i] / k;
-    }
-}
-
-template <typename T>
-void KDivX(const T* in, const T& k, T* out, size_t len)
-{
-    for(size_t i = 0; i < len; ++i)
-    {
-        out[i] = k / in[i];
-    }
-}
-
-//
 // Registration
 //
 
@@ -180,12 +183,12 @@ static Pothos::Block* makeConstArithmetic(
         if((Pothos::DType::fromDType(dtype, 1) == Pothos::DType(typeid(type))) && (opKey == operation)) \
             return new ConstArithmetic<type>(func, constant.convert<type>(), dtype.dimension());
     #define ifTypeDeclareFactory_(type) \
-        ifTypeDeclareFactory__(type, "X+K", XPlusK<type>) \
-        ifTypeDeclareFactory__(type, "X-K", XSubK<type>) \
-        ifTypeDeclareFactory__(type, "K-X", KSubX<type>) \
-        ifTypeDeclareFactory__(type, "X*K", XMultK<type>) \
-        ifTypeDeclareFactory__(type, "X/K", XDivK<type>) \
-        ifTypeDeclareFactory__(type, "K/X", KDivX<type>) 
+        ifTypeDeclareFactory__(type, "X+K", getXPlusKFcn<type>()) \
+        ifTypeDeclareFactory__(type, "X-K", getXSubKFcn<type>()) \
+        ifTypeDeclareFactory__(type, "K-X", getKSubXFcn<type>()) \
+        ifTypeDeclareFactory__(type, "X*K", getXMultKFcn<type>()) \
+        ifTypeDeclareFactory__(type, "X/K", getXDivKFcn<type>()) \
+        ifTypeDeclareFactory__(type, "K/X", getKDivXFcn<type>()) 
     #define ifTypeDeclareFactory(type) \
         ifTypeDeclareFactory_(type) \
         ifTypeDeclareFactory_(std::complex<type>)

--- a/math/Trigonometric.cpp
+++ b/math/Trigonometric.cpp
@@ -9,221 +9,229 @@
 #include <complex>
 #include <cstdint>
 #include <string>
+#include <type_traits>
+
+//
+// Implementation getters to be called on class construction
+//
 
 template <typename T>
-static void arrayCos(const T* in, T* out, size_t num)
+using TrigFunc = void(*)(const T*, T*, size_t);
+
+template <typename T>
+static inline TrigFunc<T> getCos()
 {
-    for(size_t i = 0; i < num; ++i)
+    return [](const T* in, T* out, size_t num)
     {
-        out[i] = std::cos(in[i]);
-    }
+        for (size_t i = 0; i < num; ++i) out[i] = std::cos(in[i]);
+    };
 }
 
 template <typename T>
-static void arraySin(const T* in, T* out, size_t num)
+static inline TrigFunc<T> getSin()
 {
-    for(size_t i = 0; i < num; ++i)
+    return [](const T* in, T* out, size_t num)
     {
-        out[i] = std::sin(in[i]);
-    }
+        for (size_t i = 0; i < num; ++i) out[i] = std::sin(in[i]);
+    };
 }
 
 template <typename T>
-static void arrayTan(const T* in, T* out, size_t num)
+static inline TrigFunc<T> getTan()
 {
-    for(size_t i = 0; i < num; ++i)
+    return [](const T* in, T* out, size_t num)
     {
-        out[i] = std::tan(in[i]);
-    }
+        for (size_t i = 0; i < num; ++i) out[i] = std::tan(in[i]);
+    };
 }
 
 template <typename T>
-static void arraySec(const T* in, T* out, size_t num)
+static inline TrigFunc<T> getSec()
 {
-    for(size_t i = 0; i < num; ++i)
+    return [](const T* in, T* out, size_t num)
     {
-        out[i] = T(1.0) / std::cos(in[i]);
-    }
+        for (size_t i = 0; i < num; ++i) out[i] = T(1.0) / std::cos(in[i]);
+    };
 }
 
 template <typename T>
-static void arrayCsc(const T* in, T* out, size_t num)
+static inline TrigFunc<T> getCsc()
 {
-    for(size_t i = 0; i < num; ++i)
+    return [](const T* in, T* out, size_t num)
     {
-        out[i] = T(1.0) / std::sin(in[i]);
-    }
+        for (size_t i = 0; i < num; ++i) out[i] = T(1.0) / std::sin(in[i]);
+    };
 }
 
 template <typename T>
-static void arrayCot(const T* in, T* out, size_t num)
+static inline TrigFunc<T> getCot()
 {
-    for(size_t i = 0; i < num; ++i)
+    return [](const T* in, T* out, size_t num)
     {
-        out[i] = T(1.0) / std::tan(in[i]);
-    }
+        for (size_t i = 0; i < num; ++i) out[i] = T(1.0) / std::tan(in[i]);
+    };
 }
 
 template <typename T>
-static void arrayACos(const T* in, T* out, size_t num)
+static inline TrigFunc<T> getACos()
 {
-    for(size_t i = 0; i < num; ++i)
+    return [](const T* in, T* out, size_t num)
     {
-        out[i] = std::acos(in[i]);
-    }
+        for (size_t i = 0; i < num; ++i) out[i] = std::acos(in[i]);
+    };
 }
 
 template <typename T>
-static void arrayASin(const T* in, T* out, size_t num)
+static inline TrigFunc<T> getASin()
 {
-    for(size_t i = 0; i < num; ++i)
+    return [](const T* in, T* out, size_t num)
     {
-        out[i] = std::asin(in[i]);
-    }
+        for (size_t i = 0; i < num; ++i) out[i] = std::asin(in[i]);
+    };
 }
 
 template <typename T>
-static void arrayATan(const T* in, T* out, size_t num)
+static inline TrigFunc<T> getATan()
 {
-    for(size_t i = 0; i < num; ++i)
+    return [](const T* in, T* out, size_t num)
     {
-        out[i] = std::atan(in[i]);
-    }
+        for (size_t i = 0; i < num; ++i) out[i] = std::atan(in[i]);
+    };
 }
 
 template <typename T>
-static void arrayASec(const T* in, T* out, size_t num)
+static inline TrigFunc<T> getASec()
 {
-    for(size_t i = 0; i < num; ++i)
+    return [](const T* in, T* out, size_t num)
     {
-        out[i] = std::acos(T(1.0) / in[i]);
-    }
+        for (size_t i = 0; i < num; ++i) out[i] = std::acos(T(1.0) / in[i]);
+    };
 }
 
 template <typename T>
-static void arrayACsc(const T* in, T* out, size_t num)
+static inline TrigFunc<T> getACsc()
 {
-    for(size_t i = 0; i < num; ++i)
+    return [](const T* in, T* out, size_t num)
     {
-        out[i] = std::asin(T(1.0) / in[i]);
-    }
+        for (size_t i = 0; i < num; ++i) out[i] = std::asin(T(1.0) / in[i]);
+    };
 }
 
 template <typename T>
-static void arrayACot(const T* in, T* out, size_t num)
+static inline TrigFunc<T> getACot()
 {
-    for(size_t i = 0; i < num; ++i)
+    return [](const T* in, T* out, size_t num)
     {
-        out[i] = std::atan(T(1.0) / in[i]);
-    }
+        for (size_t i = 0; i < num; ++i) out[i] = std::atan(T(1.0) / in[i]);
+    };
 }
 
 template <typename T>
-static void arrayCosH(const T* in, T* out, size_t num)
+static inline TrigFunc<T> getCosH()
 {
-    for(size_t i = 0; i < num; ++i)
+    return [](const T* in, T* out, size_t num)
     {
-        out[i] = std::cosh(in[i]);
-    }
+        for (size_t i = 0; i < num; ++i) out[i] = std::cosh(in[i]);
+    };
 }
 
 template <typename T>
-static void arraySinH(const T* in, T* out, size_t num)
+static inline TrigFunc<T> getSinH()
 {
-    for(size_t i = 0; i < num; ++i)
+    return [](const T* in, T* out, size_t num)
     {
-        out[i] = std::sinh(in[i]);
-    }
+        for (size_t i = 0; i < num; ++i) out[i] = std::sinh(in[i]);
+    };
 }
 
 template <typename T>
-static void arrayTanH(const T* in, T* out, size_t num)
+static inline TrigFunc<T> getTanH()
 {
-    for(size_t i = 0; i < num; ++i)
+    return [](const T* in, T* out, size_t num)
     {
-        out[i] = std::tanh(in[i]);
-    }
+        for (size_t i = 0; i < num; ++i) out[i] = std::tanh(in[i]);
+    };
 }
 
 template <typename T>
-static void arraySecH(const T* in, T* out, size_t num)
+static inline TrigFunc<T> getSecH()
 {
-    for(size_t i = 0; i < num; ++i)
+    return [](const T* in, T* out, size_t num)
     {
-        out[i] = T(1.0) / std::cosh(in[i]);
-    }
+        for (size_t i = 0; i < num; ++i) out[i] = T(1.0) / std::cosh(in[i]);
+    };
 }
 
 template <typename T>
-static void arrayCscH(const T* in, T* out, size_t num)
+static inline TrigFunc<T> getCscH()
 {
-    for(size_t i = 0; i < num; ++i)
+    return [](const T* in, T* out, size_t num)
     {
-        out[i] = T(1.0) / std::sinh(in[i]);
-    }
+        for (size_t i = 0; i < num; ++i) out[i] = T(1.0) / std::sinh(in[i]);
+    };
 }
 
 template <typename T>
-static void arrayCotH(const T* in, T* out, size_t num)
+static inline TrigFunc<T> getCotH()
 {
-    for(size_t i = 0; i < num; ++i)
+    return [](const T* in, T* out, size_t num)
     {
-        out[i] = T(1.0) / std::tanh(in[i]);
-    }
+        for (size_t i = 0; i < num; ++i) out[i] = T(1.0) / std::tanh(in[i]);
+    };
 }
 
 template <typename T>
-static void arrayACosH(const T* in, T* out, size_t num)
+static inline TrigFunc<T> getACosH()
 {
-    for(size_t i = 0; i < num; ++i)
+    return [](const T* in, T* out, size_t num)
     {
-        out[i] = std::acosh(in[i]);
-    }
+        for (size_t i = 0; i < num; ++i) out[i] = std::acosh(in[i]);
+    };
 }
 
 template <typename T>
-static void arrayASinH(const T* in, T* out, size_t num)
+static inline TrigFunc<T> getASinH()
 {
-    for(size_t i = 0; i < num; ++i)
+    return [](const T* in, T* out, size_t num)
     {
-        out[i] = std::asinh(in[i]);
-    }
+        for (size_t i = 0; i < num; ++i) out[i] = std::asinh(in[i]);
+    };
 }
 
 template <typename T>
-static void arrayATanH(const T* in, T* out, size_t num)
+static inline TrigFunc<T> getATanH()
 {
-    for(size_t i = 0; i < num; ++i)
+    return [](const T* in, T* out, size_t num)
     {
-        out[i] = std::atanh(in[i]);
-    }
+        for (size_t i = 0; i < num; ++i) out[i] = std::atanh(in[i]);
+    };
 }
 
 template <typename T>
-static void arrayASecH(const T* in, T* out, size_t num)
+static inline TrigFunc<T> getASecH()
 {
-    for(size_t i = 0; i < num; ++i)
+    return [](const T* in, T* out, size_t num)
     {
-        out[i] = std::acosh(T(1.0) / in[i]);
-    }
+        for (size_t i = 0; i < num; ++i) out[i] = std::acosh(T(1.0) / in[i]);
+    };
 }
 
 template <typename T>
-static void arrayACscH(const T* in, T* out, size_t num)
+static inline TrigFunc<T> getACscH()
 {
-    for(size_t i = 0; i < num; ++i)
+    return [](const T* in, T* out, size_t num)
     {
-        out[i] = std::asinh(T(1.0) / in[i]);
-    }
+        for (size_t i = 0; i < num; ++i) out[i] = std::asinh(T(1.0) / in[i]);
+    };
 }
 
 template <typename T>
-static void arrayACotH(const T* in, T* out, size_t num)
+static inline TrigFunc<T> getACotH()
 {
-    for(size_t i = 0; i < num; ++i)
+    return [](const T* in, T* out, size_t num)
     {
-        out[i] = std::atanh(T(1.0) / in[i]);
-    }
+        for (size_t i = 0; i < num; ++i) out[i] = std::atanh(T(1.0) / in[i]);
+    };
 }
 
 /***********************************************************************
@@ -302,7 +310,7 @@ template <typename T>
 class Trigonometric: public Pothos::Block
 {
 public:
-    using Func = void(*)(const T*, T*, size_t);
+    using Func = TrigFunc<T>;
     using Class = Trigonometric<T>;
 
     Trigonometric(const std::string& operation, size_t dimension)
@@ -318,33 +326,33 @@ public:
 
     void setOperation(const std::string& funcName)
     {
-        #define ifNameSetFunc(name,func) \
-            if(name == funcName) _func = Func(func<T>);
+        #define ifNameSetFunc(name, getter) \
+            if(name == funcName) _func = getter<T>();
 
-        ifNameSetFunc(     "COS",   arrayCos)
-        else ifNameSetFunc("SIN",   arraySin)
-        else ifNameSetFunc("TAN",   arrayTan)
-        else ifNameSetFunc("SEC",   arraySec)
-        else ifNameSetFunc("CSC",   arrayCsc)
-        else ifNameSetFunc("COT",   arrayCot)
-        else ifNameSetFunc("ACOS",  arrayACos)
-        else ifNameSetFunc("ASIN",  arrayASin)
-        else ifNameSetFunc("ATAN",  arrayATan)
-        else ifNameSetFunc("ASEC",  arrayASec)
-        else ifNameSetFunc("ACSC",  arrayACsc)
-        else ifNameSetFunc("ACOT",  arrayACot)
-        else ifNameSetFunc("COSH",  arrayCosH)
-        else ifNameSetFunc("SINH",  arraySinH)
-        else ifNameSetFunc("TANH",  arrayTanH)
-        else ifNameSetFunc("SECH",  arraySecH)
-        else ifNameSetFunc("CSCH",  arrayCscH)
-        else ifNameSetFunc("COTH",  arrayCotH)
-        else ifNameSetFunc("ACOSH", arrayACosH)
-        else ifNameSetFunc("ASINH", arrayASinH)
-        else ifNameSetFunc("ATANH", arrayATanH)
-        else ifNameSetFunc("ASECH", arrayASecH)
-        else ifNameSetFunc("ACSCH", arrayACscH)
-        else ifNameSetFunc("ACOTH", arrayACotH)
+        ifNameSetFunc     ("COS",   getCos)
+        else ifNameSetFunc("SIN",   getSin)
+        else ifNameSetFunc("TAN",   getTan)
+        else ifNameSetFunc("SEC",   getSec)
+        else ifNameSetFunc("CSC",   getCsc)
+        else ifNameSetFunc("COT",   getCot)
+        else ifNameSetFunc("ACOS",  getACos)
+        else ifNameSetFunc("ASIN",  getASin)
+        else ifNameSetFunc("ATAN",  getATan)
+        else ifNameSetFunc("ASEC",  getASec)
+        else ifNameSetFunc("ACSC",  getACsc)
+        else ifNameSetFunc("ACOT",  getACot)
+        else ifNameSetFunc("COSH",  getCosH)
+        else ifNameSetFunc("SINH",  getSinH)
+        else ifNameSetFunc("TANH",  getTanH)
+        else ifNameSetFunc("SECH",  getSecH)
+        else ifNameSetFunc("CSCH",  getCscH)
+        else ifNameSetFunc("COTH",  getCotH)
+        else ifNameSetFunc("ACOSH", getACosH)
+        else ifNameSetFunc("ASINH", getASinH)
+        else ifNameSetFunc("ATANH", getATanH)
+        else ifNameSetFunc("ASECH", getASecH)
+        else ifNameSetFunc("ACSCH", getACscH)
+        else ifNameSetFunc("ACOTH", getACotH)
         else throw Pothos::InvalidArgumentException("Invalid operation", funcName);
     }
 


### PR DESCRIPTION
Given that the WIP SIMD functions will need to be queried via a dynamic dispatch function, this refactor makes it easier to use one or the other based on build support or if the type itself has a SIMD implementation. This commit shouldn't change anything functionally, and as the getters are called on construction, there's no meaningful overhead.