### PR TITLE
/comms/byte_order refactor, improved type support

### DIFF
--- a/digital/ByteOrder.hpp
+++ b/digital/ByteOrder.hpp
@@ -1,0 +1,121 @@
+// Copyright (c) 2020 Nicholas Corgan
+// SPDX-License-Identifier: BSL-1.0
+
+#pragma once
+
+#include <Poco/ByteOrder.h>
+#include <Poco/Platform.h>
+
+#include <complex>
+#include <type_traits>
+
+#if POCO_OS == POCO_OS_MAC_OS_X
+#include <libkern/OSByteOrder.h>
+#endif
+
+namespace detail
+{
+    template <typename T>
+    struct IsComplex : std::false_type {};
+
+    template <typename T>
+    struct IsComplex<std::complex<T>> : std::true_type {};
+
+    template <typename T>
+    struct BufferType
+    {
+        using Type = T;
+    };
+
+    template <>
+    struct BufferType<Poco::Int16>
+    {
+        using Type = Poco::UInt16;
+    };
+
+    template <>
+    struct BufferType<Poco::Int32>
+    {
+        using Type = Poco::UInt32;
+    };
+
+    template <>
+    struct BufferType<Poco::Int64>
+    {
+        using Type = Poco::UInt64;
+    };
+
+    template <>
+    struct BufferType<float>
+    {
+        using Type = Poco::UInt32;
+    };
+
+    template <>
+    struct BufferType<double>
+    {
+        using Type = Poco::UInt64;
+    };
+
+    template <typename T>
+    struct NoReinterpretCast : std::integral_constant<bool,
+        std::is_same<T, typename BufferType<T>::Type>::value &&
+        !IsComplex<T>::value> {};
+
+    template <typename T>
+    struct MustReinterpretCast : std::integral_constant<bool,
+        !std::is_same<T, typename BufferType<T>::Type>::value &&
+        !IsComplex<T>::value> {};
+
+    // For some reason, despite specifically supporting OS X, Poco uses manual
+    // bit-shifting instead of OS X's optimized byteswap functions.
+#if POCO_OS == POCO_OS_MAC_OS_X
+    static inline Poco::UInt16 byteswap(Poco::UInt16 val)
+    {
+        return OSSwapInt16(val);
+    }
+
+    static inline Poco::UInt32 byteswap(Poco::UInt32 val)
+    {
+        return OSSwapInt32(val);
+    }
+
+    static inline Poco::UInt64 byteswap(Poco::UInt64 val)
+    {
+        return OSSwapInt64(val);
+    }
+#else
+    template <typename T>
+    static inline T byteswap(T val)
+    {
+        return Poco::ByteOrder::flipBytes(val);
+    }
+#endif
+    template <typename T>
+    static typename std::enable_if<NoReinterpretCast<T>::value, void>::type byteswapBuffer(const T* in, T* out, size_t numElements)
+    {
+        for (size_t elem = 0; elem < numElements; ++elem) out[elem] = byteswap(in[elem]);
+    }
+
+    template <typename T>
+    static typename std::enable_if<MustReinterpretCast<T>::value, void>::type byteswapBuffer(const T* in, T* out, size_t numElements)
+    {
+        using BufferType = typename BufferType<T>::Type;
+        static_assert(sizeof(T) == sizeof(BufferType), "type size mismatch");
+
+        byteswapBuffer<BufferType>((const BufferType*)in, (BufferType*)out, numElements);
+    }
+
+    template <typename T>
+    static typename std::enable_if<IsComplex<T>::value, void>::type byteswapBuffer(const T* in, T* out, size_t numElements)
+    {
+        using ScalarType = typename T::value_type;
+        byteswapBuffer<ScalarType>((const ScalarType*)in, (ScalarType*)out, (numElements * 2));
+    }
+}
+
+template <typename T>
+static void byteswapBuffer(const T* in, T* out, size_t numElements)
+{
+    detail::byteswapBuffer(in, out, numElements);
+}

--- a/digital/TestByteOrder.cpp
+++ b/digital/TestByteOrder.cpp
@@ -60,6 +60,45 @@ void _getTestParameters(
 
 template <>
 void _getTestParameters(
+    std::vector<std::int16_t>* pInputs,
+    std::vector<std::int16_t>* pSwapped)
+{
+    std::vector<std::uint16_t> uintInputs;
+    std::vector<std::uint16_t> uintSwapped;
+    _getTestParameters(&uintInputs, &uintSwapped);
+
+    (*pInputs) = reinterpretCastVector<std::uint16_t, std::int16_t>(uintInputs);
+    (*pSwapped) = reinterpretCastVector<std::uint16_t, std::int16_t>(uintSwapped);
+}
+
+template <>
+void _getTestParameters(
+    std::vector<std::int32_t>* pInputs,
+    std::vector<std::int32_t>* pSwapped)
+{
+    std::vector<std::uint32_t> uintInputs;
+    std::vector<std::uint32_t> uintSwapped;
+    _getTestParameters(&uintInputs, &uintSwapped);
+
+    (*pInputs) = reinterpretCastVector<std::uint32_t, std::int32_t>(uintInputs);
+    (*pSwapped) = reinterpretCastVector<std::uint32_t, std::int32_t>(uintSwapped);
+}
+
+template <>
+void _getTestParameters(
+    std::vector<std::int64_t>* pInputs,
+    std::vector<std::int64_t>* pSwapped)
+{
+    std::vector<std::uint64_t> uintInputs;
+    std::vector<std::uint64_t> uintSwapped;
+    _getTestParameters(&uintInputs, &uintSwapped);
+
+    (*pInputs) = reinterpretCastVector<std::uint64_t, std::int64_t>(uintInputs);
+    (*pSwapped) = reinterpretCastVector<std::uint64_t, std::int64_t>(uintSwapped);
+}
+
+template <>
+void _getTestParameters(
     std::vector<float>* pInputs,
     std::vector<float>* pSwapped)
 {
@@ -333,11 +372,17 @@ static void testByteOrder()
 
 POTHOS_TEST_BLOCK("/comms/tests", test_byte_order)
 {
+    testByteOrder<std::int16_t>();
+    testByteOrder<std::int32_t>();
+    testByteOrder<std::int64_t>();
     testByteOrder<std::uint16_t>();
     testByteOrder<std::uint32_t>();
     testByteOrder<std::uint64_t>();
     testByteOrder<float>();
     testByteOrder<double>();
+    testByteOrder<std::complex<std::int16_t>>();
+    testByteOrder<std::complex<std::int32_t>>();
+    testByteOrder<std::complex<std::int64_t>>();
     testByteOrder<std::complex<std::uint16_t>>();
     testByteOrder<std::complex<std::uint32_t>>();
     testByteOrder<std::complex<std::uint64_t>>();


### PR DESCRIPTION
* Like other blocks, use getter to get implementations
* Moved main functionality to header, will be used in SIMD functions